### PR TITLE
Working implementation of DRY with one key issue I could use help with

### DIFF
--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -433,10 +433,10 @@ static llama_token_data_array llama_sampling_prepare_impl(
     {
         const int penalty_tokens_used_size = std::min(penalty_tokens.size(), (size_t)dry_penalty_last_n);
         if (penalty_tokens_used_size) {
-            llama_sample_dry(&cur_p,
+            llama_sample_dry(ctx_main, &cur_p,
                         penalty_tokens.data() + penalty_tokens.size() - penalty_tokens_used_size,
                         penalty_tokens_used_size, dry_base, dry_multiplier, dry_allowed_length,
-                        params.dry_seq_breakers.data(), params.dry_seq_breakers.size());
+                        params.dry_seq_breakers);
         }
     }
 

--- a/common/sampling.h
+++ b/common/sampling.h
@@ -46,6 +46,8 @@ typedef struct llama_sampling_params {
     uint32_t    dry_allowed_length    = 2;
     int32_t     dry_penalty_last_n    = -1;                 // DRY last n tokens to penalize (0 = disable penalty, -1 = context size)
 
+    std::vector<std::string> dry_seq_breakers = {"\n", ":", "\"", "*"};     // default sequence breakers for DRY
+
     std::vector<llama_sampler_type> samplers_sequence = {
         llama_sampler_type::TOP_K,
         llama_sampler_type::TFS_Z,
@@ -63,9 +65,8 @@ typedef struct llama_sampling_params {
     float       cfg_scale     = 1.f; // how strong is guidance
 
     std::unordered_map<llama_token, float> logit_bias; // logit bias for specific tokens
-
     std::vector<llama_token> penalty_prompt_tokens;
-    std::vector<llama_token> dry_seq_breakers; // sequence breakers for the DRY sampler
+
     bool                     use_penalty_prompt_tokens = false;
 } llama_sampling_params;
 

--- a/include/llama.h
+++ b/include/llama.h
@@ -1085,16 +1085,17 @@ extern "C" {
                            float   p,
                           size_t   min_keep);
 
-    ///  @details DRY sampler as described in: https://github.com/oobabooga/text-generation-webui/pull/5677
-    LLAMA_API void llama_sample_dry(
-          llama_token_data_array * candidates,
-               const llama_token * last_tokens,
-                          size_t   last_tokens_size,
-                           float   dry_base,
-                           float   dry_multiplier,
-                             int   dry_allowed_length,
-               const llama_token * dry_seq_breakers,
-                          size_t   dry_seq_breakers_size);
+    // ///  @details DRY sampler as described in: https://github.com/oobabooga/text-generation-webui/pull/5677
+    // LLAMA_API void llama_sample_dry(
+    //         struct llama_context * ctx,
+    //       llama_token_data_array * candidates,
+    //            const llama_token * last_tokens,
+    //                       size_t   last_tokens_size,
+    //                        float   dry_base,
+    //                        float   dry_multiplier,
+    //                          int   dry_allowed_length,
+    //             const std::vector<std::string>
+    //                              & dry_seq_breakers);
 
     /// @details Tail Free Sampling described in https://www.trentonbricken.com/Tail-Free-Sampling/.
     LLAMA_API void llama_sample_tail_free(
@@ -1245,6 +1246,18 @@ std::pair<std::vector<uint32_t>, llama_partial_utf8> decode_utf8(
 // Randomly selects a token from the candidates based on their probabilities using given std::mt19937.
 // This is a temporary workaround in order to fix race conditions when sampling with multiple sequences.
 llama_token llama_sample_token_with_rng(struct llama_context * ctx, llama_token_data_array * candidates, std::mt19937 & rng);
+
+///  @details DRY sampler as described in: https://github.com/oobabooga/text-generation-webui/pull/5677
+LLAMA_API void llama_sample_dry(
+        struct llama_context * ctx,
+        llama_token_data_array * candidates,
+            const llama_token * last_tokens,
+                        size_t   last_tokens_size,
+                        float   dry_base,
+                        float   dry_multiplier,
+                            int   dry_allowed_length,
+            const std::vector<std::string>
+                                & dry_seq_breakers);
 
 #endif // LLAMA_API_INTERNAL
 

--- a/src/llama-sampling.h
+++ b/src/llama-sampling.h
@@ -28,7 +28,11 @@ void llama_sample_softmax_impl  (struct llama_sampling * smpl, llama_token_data_
 void llama_sample_top_k_impl    (struct llama_sampling * smpl, llama_token_data_array * candidates, int32_t k, size_t min_keep);
 void llama_sample_top_p_impl    (struct llama_sampling * smpl, llama_token_data_array * candidates, float p, size_t min_keep);
 void llama_sample_min_p_impl    (struct llama_sampling * smpl, llama_token_data_array * candidates, float p, size_t min_keep);
-void llama_sample_dry_impl      (llama_token_data_array * candidates, const llama_token * last_tokens, size_t last_tokens_size, float dry_base, float dry_multiplier, int dry_allowed_length, const llama_token * dry_seq_breakers, size_t dry_seq_breakers_size);
+std::vector<llama_token> llama_tokenize(const struct llama_context * ctx, const std::string & text, bool   add_special, bool   parse_special);
+std::vector<llama_token> llama_tokenize(const struct llama_model * model, const std::string & text, bool   add_special, bool   parse_special);
+std::string llama_detokenize(llama_context * ctx, const std::vector<llama_token> & tokens, bool special);
+std::string llama_detokenize_single(llama_context * ctx, llama_token token, bool special);
+void llama_sample_dry_impl      (struct llama_context  * ctx,  llama_token_data_array * candidates, const llama_token * last_tokens, size_t last_tokens_size, float dry_base, float dry_multiplier, int dry_allowed_length, const std::vector<std::string> & dry_seq_breakers);
 void llama_sample_tail_free_impl(struct llama_sampling * smpl, llama_token_data_array * candidates, float z, size_t min_keep);
 void llama_sample_typical_impl  (struct llama_sampling * smpl, llama_token_data_array * candidates, float p, size_t min_keep);
 void llama_sample_entropy_impl  (struct llama_sampling * smpl, llama_token_data_array * candidates, float min_temp, float max_temp, float exponent_val);

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -18935,8 +18935,8 @@ void llama_sample_min_p(struct llama_context * ctx, llama_token_data_array * can
     llama_sample_min_p_impl(ctx ? &ctx->sampling : nullptr, candidates, p, min_keep);
 }
 
-void llama_sample_dry(llama_token_data_array * candidates, const llama_token * last_tokens, size_t last_tokens_size, float dry_base, float dry_multiplier, int dry_allowed_length, const llama_token * dry_seq_breakers, size_t dry_seq_breakers_size) {
-    llama_sample_dry_impl(candidates, last_tokens, last_tokens_size, dry_base, dry_multiplier, dry_allowed_length, dry_seq_breakers, dry_seq_breakers_size);
+void llama_sample_dry(struct llama_context * ctx, llama_token_data_array * candidates, const llama_token * last_tokens, size_t last_tokens_size, float dry_base, float dry_multiplier, int dry_allowed_length, const std::vector<std::string> & dry_seq_breakers) {
+    llama_sample_dry_impl(ctx, candidates, last_tokens, last_tokens_size, dry_base, dry_multiplier, dry_allowed_length, dry_seq_breakers);
 }
 
 void llama_sample_tail_free(struct llama_context * ctx, llama_token_data_array * candidates, float z, size_t min_keep) {


### PR DESCRIPTION

- [x] I have read the [contributing guidelines](https://github.com/ggerganov/llama.cpp/blob/master/CONTRIBUTING.md)
- Self-reported review complexity:
  - [ ] Low
  - [ x ] Medium
  - [ ] High

This seems to work from my initial testing, which I will continue with, but one important issue is that I had to move the "LLAMA_API void llama_sample_dry" function signature in llama.h to the C++ "LLAMA_API_INTERNAL" section at the bottom which I am guessing is not optimal and I assume may break certain kinds of compiles that need C compatibility? I had to do this due to my use of a vector in the function signature.